### PR TITLE
bb-wl18xx-bluetooth: add BeagleBone Black wireless

### DIFF
--- a/bb-wl18xx-firmware/suite/jessie/debian/bb-wl18xx-bluetooth
+++ b/bb-wl18xx-firmware/suite/jessie/debian/bb-wl18xx-bluetooth
@@ -23,6 +23,11 @@
 
 board=$(cat /proc/device-tree/model | sed "s/ /_/g")
 case "${board}" in
+TI_AM335x_BeagleBone_Black_Wireless)
+	bt_gpio_en="28"
+	bt_port="/dev/ttyS3"
+	bt_settings="texas 300000"
+	;;
 TI_AM335x_BeagleBone_Green_Wireless)
 	bt_gpio_en="60"
 	bt_port="/dev/ttyS3"

--- a/bb-wl18xx-firmware/suite/stretch/debian/bb-wl18xx-bluetooth
+++ b/bb-wl18xx-firmware/suite/stretch/debian/bb-wl18xx-bluetooth
@@ -23,6 +23,11 @@
 
 board=$(cat /proc/device-tree/model | sed "s/ /_/g")
 case "${board}" in
+TI_AM335x_BeagleBone_Black_Wireless)
+	bt_gpio_en="28"
+	bt_port="/dev/ttyS3"
+	bt_settings="texas 300000"
+	;;
 TI_AM335x_BeagleBone_Green_Wireless)
 	bt_gpio_en="60"
 	bt_port="/dev/ttyS3"

--- a/bb-wl18xx-firmware/suite/xenial/debian/bb-wl18xx-bluetooth
+++ b/bb-wl18xx-firmware/suite/xenial/debian/bb-wl18xx-bluetooth
@@ -23,6 +23,11 @@
 
 board=$(cat /proc/device-tree/model | sed "s/ /_/g")
 case "${board}" in
+TI_AM335x_BeagleBone_Black_Wireless)
+	bt_gpio_en="28"
+	bt_port="/dev/ttyS3"
+	bt_settings="texas 300000"
+	;;
 TI_AM335x_BeagleBone_Green_Wireless)
 	bt_gpio_en="60"
 	bt_port="/dev/ttyS3"


### PR DESCRIPTION
* Uses GPIO0_28 for BT_EN

Perhaps this should be moved to a regulator in the device tree in future
versions?

Signed-off-by: Jason Kridner <jdk@ti.com>