### PR TITLE
bb-wl18xx-bluetooth.service: fix execute on boot issue

### DIFF
--- a/bb-wl18xx-firmware/suite/jessie/debian/bb-wl18xx-bluetooth.service
+++ b/bb-wl18xx-firmware/suite/jessie/debian/bb-wl18xx-bluetooth.service
@@ -4,6 +4,7 @@ After=getty.target bluetooth.service generic-board-startup.service
 
 [Service]
 ExecStart=/usr/bin/bb-wl18xx-bluetooth
+Type=forking
 
 [Install]
 WantedBy=multi-user.target

--- a/bb-wl18xx-firmware/suite/stretch/debian/bb-wl18xx-bluetooth.service
+++ b/bb-wl18xx-firmware/suite/stretch/debian/bb-wl18xx-bluetooth.service
@@ -4,6 +4,7 @@ After=getty.target bluetooth.service generic-board-startup.service
 
 [Service]
 ExecStart=/usr/bin/bb-wl18xx-bluetooth
+Type=forking
 
 [Install]
 WantedBy=multi-user.target

--- a/bb-wl18xx-firmware/suite/xenial/debian/bb-wl18xx-bluetooth.service
+++ b/bb-wl18xx-firmware/suite/xenial/debian/bb-wl18xx-bluetooth.service
@@ -4,6 +4,7 @@ After=getty.target bluetooth.service generic-board-startup.service
 
 [Service]
 ExecStart=/usr/bin/bb-wl18xx-bluetooth
+Type=forking
 
 [Install]
 WantedBy=multi-user.target

--- a/bb-wl18xx-firmware/suite/yakkety/debian/bb-wl18xx-bluetooth.service
+++ b/bb-wl18xx-firmware/suite/yakkety/debian/bb-wl18xx-bluetooth.service
@@ -4,6 +4,7 @@ After=getty.target bluetooth.service generic-board-startup.service
 
 [Service]
 ExecStart=/usr/bin/bb-wl18xx-bluetooth
+Type=forking
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This works beautifully.

From a fresh boot:
```
root@beaglebone:/var/lib/cloud9# bluetoothctl
[NEW] Controller 5C:31:3E:E2:24:69 beaglebone [default]
[bluetooth]# scan on
Discovery started
[CHG] Controller 5C:31:3E:E2:24:69 Discovering: yes
[NEW] Device XX:XX:XX:XX:XX:XX XXXXXXX
[bluetooth]# quit
[DEL] Controller 5C:31:3E:E2:24:69 beaglebone [default]
root@beaglebone:/var/lib/cloud9# 
```