### PR TITLE
reset Bluetooth pin before trying to enable if it was on

### DIFF
--- a/bb-wl18xx-firmware/suite/jessie/debian/bb-wl18xx-bluetooth
+++ b/bb-wl18xx-firmware/suite/jessie/debian/bb-wl18xx-bluetooth
@@ -73,6 +73,11 @@ hciattach_bin=$(which hciattach)
 
 if [ -f ${hciattach_bin} ] ; then
 	if [ -f /sys/class/leds/wl18xx_bt_en/brightness ] ; then
+		# Resetting the Bluetooth enable pin
+		if [ `cat /sys/class/leds/wl18xx_bt_en/brightness` = "${bt_enable}" ]; then
+			echo 0 > /sys/class/leds/wl18xx_bt_en/brightness || true
+			sleep 1
+		fi
 		echo ${bt_enable} > /sys/class/leds/wl18xx_bt_en/brightness || true
 		${hciattach_bin} ${bt_port} ${bt_settings} || true
 	else

--- a/bb-wl18xx-firmware/suite/stretch/debian/bb-wl18xx-bluetooth
+++ b/bb-wl18xx-firmware/suite/stretch/debian/bb-wl18xx-bluetooth
@@ -73,6 +73,11 @@ hciattach_bin=$(which hciattach)
 
 if [ -f ${hciattach_bin} ] ; then
 	if [ -f /sys/class/leds/wl18xx_bt_en/brightness ] ; then
+		# Resetting the Bluetooth enable pin
+		if [ `cat /sys/class/leds/wl18xx_bt_en/brightness` = "${bt_enable}" ]; then
+			echo 0 > /sys/class/leds/wl18xx_bt_en/brightness || true
+			sleep 1
+		fi
 		echo ${bt_enable} > /sys/class/leds/wl18xx_bt_en/brightness || true
 		${hciattach_bin} ${bt_port} ${bt_settings} || true
 	else

--- a/bb-wl18xx-firmware/suite/xenial/debian/bb-wl18xx-bluetooth
+++ b/bb-wl18xx-firmware/suite/xenial/debian/bb-wl18xx-bluetooth
@@ -73,6 +73,11 @@ hciattach_bin=$(which hciattach)
 
 if [ -f ${hciattach_bin} ] ; then
 	if [ -f /sys/class/leds/wl18xx_bt_en/brightness ] ; then
+		# Resetting the Bluetooth enable pin
+		if [ `cat /sys/class/leds/wl18xx_bt_en/brightness` = "${bt_enable}" ]; then
+			echo 0 > /sys/class/leds/wl18xx_bt_en/brightness || true
+			sleep 1
+		fi
 		echo ${bt_enable} > /sys/class/leds/wl18xx_bt_en/brightness || true
 		${hciattach_bin} ${bt_port} ${bt_settings} || true
 	else

--- a/bb-wl18xx-firmware/suite/yakkety/debian/bb-wl18xx-bluetooth
+++ b/bb-wl18xx-firmware/suite/yakkety/debian/bb-wl18xx-bluetooth
@@ -73,6 +73,11 @@ hciattach_bin=$(which hciattach)
 
 if [ -f ${hciattach_bin} ] ; then
 	if [ -f /sys/class/leds/wl18xx_bt_en/brightness ] ; then
+		# Resetting the Bluetooth enable pin
+		if [ `cat /sys/class/leds/wl18xx_bt_en/brightness` = "${bt_enable}" ]; then
+			echo 0 > /sys/class/leds/wl18xx_bt_en/brightness || true
+			sleep 1
+		fi
 		echo ${bt_enable} > /sys/class/leds/wl18xx_bt_en/brightness || true
 		${hciattach_bin} ${bt_port} ${bt_settings} || true
 	else

--- a/bb-wl18xx-firmware/suite/zesty/debian/bb-wl18xx-bluetooth
+++ b/bb-wl18xx-firmware/suite/zesty/debian/bb-wl18xx-bluetooth
@@ -73,6 +73,11 @@ hciattach_bin=$(which hciattach)
 
 if [ -f ${hciattach_bin} ] ; then
 	if [ -f /sys/class/leds/wl18xx_bt_en/brightness ] ; then
+		# Resetting the Bluetooth enable pin
+		if [ `cat /sys/class/leds/wl18xx_bt_en/brightness` = "${bt_enable}" ]; then
+			echo 0 > /sys/class/leds/wl18xx_bt_en/brightness || true
+			sleep 1
+		fi
 		echo ${bt_enable} > /sys/class/leds/wl18xx_bt_en/brightness || true
 		${hciattach_bin} ${bt_port} ${bt_settings} || true
 	else


### PR DESCRIPTION
Previous version of code misbehaves under containerized applications. In the first run of the application the Bluetooth enable pin is set, and hciattach called. On application restart (but not whole device reboot) hciattach will be killed, but the enable pin stays as it was. Then when running this code again on the start, Bluetooth enable fails and initialization times out. To prevent that to happen, if the Bluetooth enable is on, toggle it (disable then enable again)
to reset the hardware.