### PR TITLE
Upgrade pru-gcc to 2016.12-beta-rc2

### DIFF
--- a/binutils-pru/suite/jessie/debian/changelog
+++ b/binutils-pru/suite/jessie/debian/changelog
@@ -1,3 +1,14 @@
+binutils-pru (2.28.51.20161231) jessie; urgency=medium
+
+  * ld: Switched relocations to be more compatible with TI's toolchain. YOU MUST RECOMPILE ALL YOUR SOURCE FILES - object files from old and new binutils cannot be linked together.
+  * gas: Added WBC and WBS pseudo ops to GAS.
+  * gas: Added optional & prefix for addressed registers
+  * gas/ld: Removed %hi/%lo/%hi_rlz assembler constructs and instead implemented LDI32 pseudo instruction.
+  * gas: Switched to r3.w2 as Return Address Register for the call and ret pseudos.
+  * gas: Added %label() construct to allow disambiguating register from label JMP operands.
+
+ -- Dimitar Dimitrov <dinux@tpdeb>  Sat, 31 Dec 2016 10:44:41 +0200
+
 binutils-pru (2.27.51.20160801-0rcnee0~bpo80+20160802+1) jessie; urgency=low
 
   * Rebuild for repos.rcn-ee.com

--- a/binutils-pru/suite/jessie/debian/rules
+++ b/binutils-pru/suite/jessie/debian/rules
@@ -18,6 +18,7 @@ CONFARGS = --prefix=/usr \
            --target=$(TARGET) \
            --with-gnu-ld \
            --with-gnu-as \
+           --disable-gdb \
            --enable-install-libbfd \
 	   --with-bugurl="https://github.com/dinuxbg/gnupru/issues" \
            $(shell dpkg-buildflags --export=configure) 

--- a/binutils-pru/version.sh
+++ b/binutils-pru/version.sh
@@ -2,8 +2,8 @@
 
 package_name="binutils-pru"
 debian_pkg_name="${package_name}"
-gnupru_release="2016.07-beta-rc1.1"
-package_version="2.27.51.20160801"
+gnupru_release="2016.12-beta-rc2"
+package_version="2.28.51.20161231"
 package_source=""
 src_dir=""
 
@@ -16,4 +16,4 @@ debian_version="${package_version}-0rcnee0"
 debian_untar=""
 debian_patch=""
 
-jessie_version="~bpo80+20160802+1"
+jessie_version="~bpo80+20161231+1"

--- a/gcc-pru/suite/jessie/debian/changelog
+++ b/gcc-pru/suite/jessie/debian/changelog
@@ -1,3 +1,10 @@
+gcc-pru (7.0.0.20161219) jessie; urgency=medium
+
+  * Fixed invalid-syntax assembler generation on 32bit hosts.
+  * Removed leading underscore for symbols for better TI ABI compatibility.
+
+ -- Dimitar Dimitrov <dinux@tpdeb>  Sat, 31 Dec 2016 10:50:00 +0200
+
 gcc-pru (7.0.0.20160801-0rcnee0~bpo80+20160803+1) jessie; urgency=low
 
   * Rebuild for repos.rcn-ee.com

--- a/gcc-pru/suite/jessie/debian/control
+++ b/gcc-pru/suite/jessie/debian/control
@@ -3,14 +3,14 @@ Section: devel
 Priority: extra
 Maintainer: Dimitar Dimitrov <dinuxbg@gmail.com>
 Standards-Version: 3.9.5
-Build-Depends: m4, autoconf2.64, libtool, bzip2, binutils-pru (>= 2.25), bison, flex, gettext, texinfo, zlib1g-dev, debhelper (>= 4.2.10), tar (>= 1.13.18), libmpfr-dev, lsb-release, patchutils, libmpc-dev, dpkg (>= 1.16.2), dh-autoreconf
+Build-Depends: m4, autoconf2.64, libtool, bzip2, binutils-pru (>= 2.28.51.20161231), bison, flex, gettext, texinfo, zlib1g-dev, debhelper (>= 4.2.10), tar (>= 1.13.18), libmpfr-dev, lsb-release, patchutils, libmpc-dev, dpkg (>= 1.16.2), dh-autoreconf
 Build-Conflicts: libgcc0, libgcc300
 
 Package: gcc-pru
 Architecture: any
 Section: devel
 Priority: extra
-Depends: ${shlibs:Depends}, ${misc:Depends}, binutils-pru (>= 2.25)
+Depends: ${shlibs:Depends}, ${misc:Depends}, binutils-pru (>= 2.28.51.20161231)
 Provides: c-compiler-pru
 Suggests: task-c-devel, gcc-doc (>= 4:4.8), gcc (>= 4:4.8)
 Description: GNU C compiler (cross compiler for pru)

--- a/gcc-pru/version.sh
+++ b/gcc-pru/version.sh
@@ -2,8 +2,8 @@
 
 package_name="gcc-pru"
 debian_pkg_name="${package_name}"
-gnupru_release="2016.07-beta-rc1.1"
-package_version="7.0.0.20160801"
+gnupru_release="2016.12-beta-rc2"
+package_version="7.0.0.20161219"
 package_source=""
 src_dir=""
 
@@ -16,4 +16,4 @@ debian_version="${package_version}-0rcnee0"
 debian_untar=""
 debian_patch=""
 
-jessie_version="~bpo80+20160803+1"
+jessie_version="~bpo80+20161231+1"


### PR DESCRIPTION
Note that binutils must be upgraded and installed prior to building
the new GCC. This is due to some ABI-breaking changes since BETA-rc1.

Binutils ABI should be stable from this point on - PRU port has been
mainlined, and it should be mostly compatible with TI's CLPRU ELF ABI.

Testing done:
  I used sbuild on x86 to build the packages. Since I have not made any changes to the build and release scripts, I do not expect issues for armhf.

Signed-off-by: Dimitar Dimitrov <dimitar@dinux.eu>