### PR TITLE
Binutils/GCC PRU release 2016.12-beta-rc2.1

### DIFF
--- a/binutils-pru/suite/jessie/debian/changelog
+++ b/binutils-pru/suite/jessie/debian/changelog
@@ -1,3 +1,9 @@
+binutils-pru (2.28.51.20170102) jessie; urgency=medium
+
+  * A few fixes for 32-bit hosts.
+
+ -- Dimitar Dimitrov <dinux@tpdeb>  Mon, 02 Jan 2017 11:45:54 +0200
+
 binutils-pru (2.28.51.20161231-0rcnee0~bpo80+20170101+1) jessie; urgency=low
 
   * Rebuild for repos.rcn-ee.com

--- a/binutils-pru/suite/jessie/debian/rules
+++ b/binutils-pru/suite/jessie/debian/rules
@@ -61,7 +61,7 @@ configure-stamp: unpack-stamp patch-stamp
 	touch configure-stamp
 
 build: configure-stamp build-stamp
-build-stamp:
+build-stamp: configure-stamp
 	dh_testdir
 
 	# Add here commands to compile the package.

--- a/binutils-pru/version.sh
+++ b/binutils-pru/version.sh
@@ -2,8 +2,8 @@
 
 package_name="binutils-pru"
 debian_pkg_name="${package_name}"
-gnupru_release="2016.12-beta-rc2"
-package_version="2.28.51.20161231"
+gnupru_release="2016.12-beta-rc2.1"
+package_version="2.28.51.20170102"
 package_source=""
 src_dir=""
 

--- a/gcc-pru/suite/jessie/debian/rules
+++ b/gcc-pru/suite/jessie/debian/rules
@@ -76,7 +76,7 @@ configure-stamp: $(unpack_stamp) patch-stamp
 	touch configure-stamp
 
 build: configure-stamp build-stamp
-build-stamp: patch-stamp
+build-stamp: patch-stamp configure-stamp
 	dh_testdir
 
 	# Add here commands to compile the package.


### PR DESCRIPTION
New 2016.12-beta-rc2.1 contains a few fixes for 32-bit hosts.

I have tested jessie-i386 and jessie-amd64 hosts using sbuild.

Signed-off-by: Dimitar Dimitrov <dimitar@dinux.eu>