### PR TITLE
update roboticscape version to 0.3.1

### DIFF
--- a/strawsondesign-8-roboticscape/version.sh
+++ b/strawsondesign-8-roboticscape/version.sh
@@ -4,16 +4,16 @@
 
 package_name="roboticscape"
 debian_pkg_name="${package_name}"
-package_version="0.2.2-git20161122"
+package_version="0.3.1"
 package_source="${package_name}_${package_version}.orig.tar.xz"
 src_dir="${package_name}_${package_version}"
 
 git_repo="https://github.com/StrawsonDesign/Robotics_Cape_Installer"
-git_sha="8a6ec2d140cf718e7aa7f24b935c34edb7cf7cc3"
+git_sha="8790d7b4de18a343cb22de85b8764ca4ae12082e"
 reprepro_dir="r/${package_name}"
 dl_path=""
 
-debian_version="${package_version}-0rcnee9"
+debian_version="${package_version}"
 debian_patch=""
 debian_diff=""
 


### PR DESCRIPTION
Not sure if this is right! If anything is wrong please let me know so there can be less hand-holding in the future. I got the SHA checksum with "git rev-parse --verify HEAD"