### PR TITLE
Enable non-root user access to the eQEP modules

### DIFF
--- a/bb-customizations/suite/buster/debian/83-eqep-noroot.rules
+++ b/bb-customizations/suite/buster/debian/83-eqep-noroot.rules
@@ -1,0 +1,9 @@
+# /etc/udev/rules.d/83-eqep-noroot.rules
+#
+# Corrects sys eQEP permissions on the Beaglebone so non-root users in the eqep
+# group can access the Quadrature Encoder Pulse modules
+#
+# Change group to eqep
+SUBSYSTEM=="platform", DRIVER=="eqep", PROGRAM="/bin/sh -c '/bin/chown -R root:eqep /sys/devices/platform/ocp/*.epwmss/*.eqep'"
+# Change user permissions to ensure user and group have read/write permissions
+SUBSYSTEM=="platform", DRIVER=="eqep", PROGRAM="/bin/sh -c '/bin/chmod -R ug+rw /sys/devices/platform/ocp/*.epwmss/*.eqep'"

--- a/bb-customizations/suite/buster/debian/changelog
+++ b/bb-customizations/suite/buster/debian/changelog
@@ -1,3 +1,10 @@
+bb-customizations (1.20170718-0rcnee0~buster+20171123) buster; urgency=low
+
+  * Added udev rule to enable acces to the eQEP modules as a non-root user.
+    The user must be part of the eqep group to be granted access.
+
+ -- David Planella <david.planella@ubuntu.com>  Thu, 23 Nov 2017 15:42:30 +0100
+
 bb-customizations (1.20170718-0rcnee0~buster+20170718) buster; urgency=low
 
   * Rebuild for repos.rcn-ee.com

--- a/bb-customizations/suite/buster/debian/install
+++ b/bb-customizations/suite/buster/debian/install
@@ -2,6 +2,7 @@ debian/60-omap-tty.rules /etc/udev/rules.d/
 debian/80-gpio-noroot.rules /etc/udev/rules.d/
 debian/81-pwm-noroot.rules /etc/udev/rules.d/
 debian/82-gpio-config-pin.rules /etc/udev/rules.d/
+debian/83-eqep-noroot.rules /etc/udev/rules.d/
 debian/dtbo /usr/share/initramfs-tools/hooks/
 debian/ti_pru_firmware /usr/share/initramfs-tools/hooks/
 debian/generic-board-startup.service /lib/systemd/system/

--- a/bb-customizations/suite/buster/debian/postinst
+++ b/bb-customizations/suite/buster/debian/postinst
@@ -11,5 +11,6 @@ fi
 
 groupadd gpio --system || true
 groupadd pwm --system || true
+groupadd eqep --system || true
 
 #DEBHELPER#


### PR DESCRIPTION
This change enables non-root users who are part of the eqep group to access the sysfs attributes needed to control the eQEP modules from user space. As an example, it allows resetting the position attribute to 0 or to an arbitrary position without the need to elevate privileges.

It's implemented as a udev rule follow the convention set by the other subsystems that need to be accessed as non-root (80-gpio-noroot.rules and 81-pwm-noroot.rules). Following a similar practice, a new, dedicated 'eqep' group was added.