### PR TITLE
Update PRU gcc and binutils

### DIFF
--- a/binutils-pru/suite/jessie/debian/changelog
+++ b/binutils-pru/suite/jessie/debian/changelog
@@ -1,3 +1,10 @@
+binutils-pru (2.30.51.20180310) jessie; urgency=medium
+
+  * ld: Switched relocations to be more compatible with TI's toolchain. YOU MUST RECOMPILE ALL YOUR SOURCE FILES - object files from old and new binutils cannot be linked together.
+  * Rebased to latest baseline.
+
+ -- Dimitar Dimitrov <dinux@tpdeb>  Mon, 12 Mar 2018 20:54:12 +0200
+
 binutils-pru (2.28.51.20170530~jessie+20170925) jessie; urgency=low
 
   * Rebuild for repos.rcn-ee.com

--- a/binutils-pru/suite/stretch/debian/changelog
+++ b/binutils-pru/suite/stretch/debian/changelog
@@ -1,3 +1,10 @@
+binutils-pru (2.30.51.20180310) stretch; urgency=medium
+
+  * ld: Switched relocations to be more compatible with TI's toolchain. YOU MUST RECOMPILE ALL YOUR SOURCE FILES - object files from old and new binutils cannot be linked together.
+  * Rebased to latest baseline.
+
+ -- Dimitar Dimitrov <dinux@tpdeb>  Mon, 12 Mar 2018 20:54:12 +0200
+
 binutils-pru (2.28.51.20170530~stretch+20170925) stretch; urgency=low
 
   * Rebuild for repos.rcn-ee.com

--- a/binutils-pru/version.sh
+++ b/binutils-pru/version.sh
@@ -2,8 +2,8 @@
 
 package_name="binutils-pru"
 debian_pkg_name="${package_name}"
-gnupru_release="2017.09-beta-rc2.2"
-package_version="2.28.51.20170530"
+gnupru_release="2018.03-beta-rc3"
+package_version="2.30.51.20180310"
 package_source=""
 src_dir=""
 
@@ -16,5 +16,5 @@ debian_version="${package_version}"
 debian_untar=""
 debian_patch=""
 
-jessie_version="~jessie+20170925"
-stretch_version="~stretch+20170925"
+jessie_version="~jessie+20180317"
+stretch_version="~stretch+20180317"

--- a/gcc-pru/suite/jessie/debian/changelog
+++ b/gcc-pru/suite/jessie/debian/changelog
@@ -1,3 +1,10 @@
+gcc-pru (8.0.1.20180310) jessie; urgency=medium
+
+  * GCC PRU port has been overhauled to better support TI ABI.
+  * When linking object files from GCC and TI toolchains, you must use the -mabi=ti option.
+
+ -- Dimitar Dimitrov <dinux@tpdeb>  Mon, 12 Mar 2018 20:59:11 +0200
+
 gcc-pru (8.0.0.20170530-0rcnee0~jessie+20170925) jessie; urgency=low
 
   * Rebuild for repos.rcn-ee.com

--- a/gcc-pru/suite/jessie/debian/control
+++ b/gcc-pru/suite/jessie/debian/control
@@ -3,14 +3,14 @@ Section: devel
 Priority: extra
 Maintainer: Dimitar Dimitrov <dinuxbg@gmail.com>
 Standards-Version: 3.9.5
-Build-Depends: m4, autoconf2.64, libtool, bzip2, binutils-pru (>= 2.28.51.20161231), bison, flex, gettext, texinfo, zlib1g-dev, debhelper (>= 4.2.10), tar (>= 1.13.18), libmpfr-dev, lsb-release, patchutils, libmpc-dev, dpkg (>= 1.16.2), dh-autoreconf
+Build-Depends: m4, autoconf2.64, libtool, bzip2, binutils-pru (>= 2.30.51.20180310), bison, flex, gettext, texinfo, zlib1g-dev, debhelper (>= 4.2.10), tar (>= 1.13.18), libmpfr-dev, lsb-release, patchutils, libmpc-dev, dpkg (>= 1.16.2), dh-autoreconf
 Build-Conflicts: libgcc0, libgcc300
 
 Package: gcc-pru
 Architecture: any
 Section: devel
 Priority: extra
-Depends: ${shlibs:Depends}, ${misc:Depends}, binutils-pru (>= 2.28.51.20161231)
+Depends: ${shlibs:Depends}, ${misc:Depends}, binutils-pru (>= 2.30.51.20180310)
 Provides: c-compiler-pru
 Suggests: task-c-devel, gcc-doc (>= 4:4.8), gcc (>= 4:4.8)
 Description: GNU C compiler (cross compiler for pru)

--- a/gcc-pru/suite/stretch/debian/changelog
+++ b/gcc-pru/suite/stretch/debian/changelog
@@ -1,3 +1,10 @@
+gcc-pru (8.0.1.20180310) stretch; urgency=medium
+
+  * GCC PRU port has been overhauled to better support TI ABI.
+  * When linking object files from GCC and TI toolchains, you must use the -mabi=ti option.
+
+ -- Dimitar Dimitrov <dinux@tpdeb>  Mon, 12 Mar 2018 20:59:11 +0200
+
 gcc-pru (8.0.0.20170530-0rcnee0~stretch+20170925) stretch; urgency=low
 
   * Rebuild for repos.rcn-ee.com

--- a/gcc-pru/suite/stretch/debian/control
+++ b/gcc-pru/suite/stretch/debian/control
@@ -3,14 +3,14 @@ Section: devel
 Priority: extra
 Maintainer: Dimitar Dimitrov <dinuxbg@gmail.com>
 Standards-Version: 3.9.5
-Build-Depends: m4, autoconf2.64, libtool, bzip2, binutils-pru (>= 2.28.51.20161231), bison, flex, gettext, texinfo, zlib1g-dev, debhelper (>= 4.2.10), tar (>= 1.13.18), libmpfr-dev, lsb-release, patchutils, libmpc-dev, dpkg (>= 1.16.2), dh-autoreconf
+Build-Depends: m4, autoconf2.64, libtool, bzip2, binutils-pru (>= 2.30.51.20180310), bison, flex, gettext, texinfo, zlib1g-dev, debhelper (>= 4.2.10), tar (>= 1.13.18), libmpfr-dev, lsb-release, patchutils, libmpc-dev, dpkg (>= 1.16.2), dh-autoreconf
 Build-Conflicts: libgcc0, libgcc300
 
 Package: gcc-pru
 Architecture: any
 Section: devel
 Priority: extra
-Depends: ${shlibs:Depends}, ${misc:Depends}, binutils-pru (>= 2.28.51.20161231)
+Depends: ${shlibs:Depends}, ${misc:Depends}, binutils-pru (>= 2.30.51.20180310)
 Provides: c-compiler-pru
 Suggests: task-c-devel, gcc-doc (>= 4:4.8), gcc (>= 4:4.8)
 Description: GNU C compiler (cross compiler for pru)

--- a/gcc-pru/version.sh
+++ b/gcc-pru/version.sh
@@ -2,8 +2,8 @@
 
 package_name="gcc-pru"
 debian_pkg_name="${package_name}"
-gnupru_release="2017.09-beta-rc2.2"
-package_version="8.0.0.20170530"
+gnupru_release="2018.03-beta-rc3"
+package_version="8.0.1.20180310"
 package_source=""
 src_dir=""
 
@@ -16,5 +16,5 @@ debian_version="${package_version}-0rcnee0"
 debian_untar=""
 debian_patch=""
 
-jessie_version="~jessie+20170925"
-stretch_version="~stretch+20170925"
+jessie_version="~jessie+20180317"
+stretch_version="~stretch+20180317"


### PR DESCRIPTION
New major version with better ABI support.

FYI: Building pru-gcc debian package on my QEMU arm chroot takes a few days. I'm still waiting for it to finish, but I don't expect problems at this point. I've tested the x85_64 debian packages. Let me know if you find a build issue.

Signed-off-by: Dimitar Dimitrov <dimitar@dinux.eu>