### PR TITLE
fix gpiochip udev rules in stretch and buster

### DIFF
--- a/bb-customizations/suite/buster/debian/85-gpio-noroot.rules
+++ b/bb-customizations/suite/buster/debian/85-gpio-noroot.rules
@@ -2,8 +2,5 @@
 #
 # Corrects sys GPIO permissions on the BB so non-root users in the gpio group can manipulate bits
 #
-# Change group to gpio
-SUBSYSTEM=="gpio", PROGRAM="/bin/sh -c '/bin/chown -R root:gpio /dev/gpiochip*'"
-# Change user permissions to ensure user and group have read/write permissions
-SUBSYSTEM=="gpio", PROGRAM="/bin/sh -c '/bin/chmod -R ug+rw /dev/gpiochip*'"
 
+SUBSYSTEM=="gpio", GROUP="gpio", MODE="0660"

--- a/bb-customizations/suite/stretch/debian/85-gpio-noroot.rules
+++ b/bb-customizations/suite/stretch/debian/85-gpio-noroot.rules
@@ -2,8 +2,5 @@
 #
 # Corrects sys GPIO permissions on the BB so non-root users in the gpio group can manipulate bits
 #
-# Change group to gpio
-SUBSYSTEM=="gpio", PROGRAM="/bin/sh -c '/bin/chown -R root:gpio /dev/gpiochip*'"
-# Change user permissions to ensure user and group have read/write permissions
-SUBSYSTEM=="gpio", PROGRAM="/bin/sh -c '/bin/chmod -R ug+rw /dev/gpiochip*'"
 
+SUBSYSTEM=="gpio", GROUP="gpio", MODE="0660"


### PR DESCRIPTION
no more race condition, /dev/gpiochip have correct and predictable permissions now.