### PR TITLE
apply udev gpio rules to pins listed by BGA pin#

### DIFF
--- a/bb-customizations/suite/stretch/debian/82-gpio-config-pin.rules
+++ b/bb-customizations/suite/stretch/debian/82-gpio-config-pin.rules
@@ -3,6 +3,6 @@
 # Corrects sys GPIO permissions on the BB so non-root users in the gpio group can manipulate bits
 #
 # Change group to gpio
-SUBSYSTEM=="gpio", PROGRAM="/bin/sh -c '/bin/chown -R root:gpio /sys/devices/platform/ocp/ocp\:P*pinmux'"
+SUBSYSTEM=="gpio", PROGRAM="/bin/sh -c '/bin/chown -R root:gpio /sys/devices/platform/ocp/ocp\:*pinmux'"
 # Change user permissions to ensure user and group have read/write permissions
-SUBSYSTEM=="gpio", PROGRAM="/bin/sh -c '/bin/chmod -R ug+rw /sys/devices/platform/ocp/ocp\:P*pinmux'"
+SUBSYSTEM=="gpio", PROGRAM="/bin/sh -c '/bin/chmod -R ug+rw /sys/devices/platform/ocp/ocp\:*pinmux'"


### PR DESCRIPTION
currently only header pins configured for pinmux get the udev treatment, this lets it apply to the BB Blue's other pins too.