### PR TITLE
gcc-pru: Switch to official 10.1.0 release

### DIFF
--- a/gcc-pru/generate_source.sh
+++ b/gcc-pru/generate_source.sh
@@ -5,8 +5,7 @@
 # rm *.tar.xz || true
 rm *.tar.bz2 || true
 
-# TODO - switch to http://ftpmirror.gnu.org/gcc once gcc-10 is released.
-wget http://www.netgull.com/gcc/snapshots/${package_version}/gcc-${package_version}.tar.xz
+wget http://ftpmirror.gnu.org/gcc/gcc-${package_version}/gcc-${package_version}.tar.xz
 
 wget http://sourceware.org/pub/newlib/newlib-${newlib_version}.tar.gz
 

--- a/gcc-pru/version.sh
+++ b/gcc-pru/version.sh
@@ -2,7 +2,7 @@
 
 package_name="gcc-pru"
 debian_pkg_name="${package_name}"
-package_version="10-20200315"
+package_version="10.1.0"
 package_source=""
 src_dir=""
 


### PR DESCRIPTION
It is no longer necessary to rely on snapshot tarballs. The
official 10.1.0 is out on GNU mirrors.

I have not tested a build, and I have not updated changelogs.

Since diff between previous snapshot and official 10.1.0 is small,
this is both small risk and low priority commit.

Signed-off-by: Dimitar Dimitrov <dimitar@dinux.eu>