### PR TITLE
Bump gnuprumcu version

### DIFF
--- a/gnuprumcu/version.sh
+++ b/gnuprumcu/version.sh
@@ -2,12 +2,12 @@
 
 package_name="gnuprumcu"
 debian_pkg_name="${package_name}"
-package_version="0.2.1-git20191109.0"
+package_version="0.3.0-git20200828.0"
 package_source="${package_name}_${package_version}.orig.tar.xz"
 src_dir="${package_name}_${package_version}"
 
 git_repo="https://github.com/dinuxbg/gnuprumcu"
-git_sha="81efdc0d816174840c71d40664ee6410f61a770a"
+git_sha="b62dfbc2cf1e8ad19e845141e7e3a6c077a6c4d5"
 reprepro_dir="b/${package_name}"
 dl_path=""
 


### PR DESCRIPTION
Changes in 0.3.0 since last 0.2.1:
 * Aligned am335x.h to latest TRM. THIS MAY BREAK SOURCE BUILDS FOR EXISTING USER FIRMWARE!
 * Added am527x.h header.

I did not touch existing debian changelogs because I see RCN is bumping
them always, perhaps by a script.

Signed-off-by: Dimitar Dimitrov <dimitar@dinux.eu>