### PR TITLE
bbb.io-beagleconnect

### DIFF
--- a/bbb.io-beagleconnect/suite/bullseye/debian/install
+++ b/bbb.io-beagleconnect/suite/bullseye/debian/install
@@ -1,3 +1,3 @@
 debian/beagleconnect.conf /etc/modules-load.d/
-debian/beagleconnect-start-gateway /usr/bin/
-gbridge/gbridge /usr/bin/
+debian/beagleconnect-start-gateway /usr/sbin/
+gbridge/gbridge /usr/sbin/


### PR DESCRIPTION
beagleconnect-start-gateway and gbridge should both only be run by the root user as of now. At some point, gbridge should either be rewritten in Rust and/or put into the kernel. BTW, how do you find the gbridge sources based on this repository?