### PR TITLE
Update the PRU GCC toolchain

### DIFF
--- a/binutils-pru/generate_source.sh
+++ b/binutils-pru/generate_source.sh
@@ -7,7 +7,9 @@ do
   OLD=`pwd`
   cd $d
   rm *.tar.bz2 || true
-  wget http://ftpmirror.gnu.org/binutils/binutils-${package_version}.tar.bz2
+  # TODO - once Binutils 2.38 is released, switch back to official tarballs.
+  # wget http://ftpmirror.gnu.org/binutils/binutils-${package_version}.tar.bz2
+  wget http://dinux.eu/gnupru/binutils-2.37.50.g2749ac13.tar.bz2
   cd $OLD
 done
 

--- a/binutils-pru/suite/bionic/debian/changelog
+++ b/binutils-pru/suite/bionic/debian/changelog
@@ -1,3 +1,11 @@
+binutils-pru (2.37.50.g2749ac13-0rcnee4~bionic+20200321) bionic; urgency=low
+
+  * Binutils 2.37.50, mainline commit 2749ac133972d027fe9482acc81f6e88c4f36812.
+  * Fix handling of .pri_irq_map section.
+  * Fix .resource_table section alignment for AM64x SoCs.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Sun, 12 Dec 2021 20:54:12 +0200
+
 binutils-pru (2.34-0rcnee4~bionic+20200321) bionic; urgency=low
 
   * Rebuild for repos.rcn-ee.com

--- a/binutils-pru/suite/bullseye/debian/changelog
+++ b/binutils-pru/suite/bullseye/debian/changelog
@@ -1,3 +1,11 @@
+binutils-pru (2.37.50.g2749ac13-0rcnee4~bullseye+20200321) bullseye; urgency=low
+
+  * Binutils 2.37.50, mainline commit 2749ac133972d027fe9482acc81f6e88c4f36812.
+  * Fix handling of .pri_irq_map section.
+  * Fix .resource_table section alignment for AM64x SoCs.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Sun, 12 Dec 2021 20:54:12 +0200
+
 binutils-pru (2.34-0rcnee4~bullseye+20200321) bullseye; urgency=low
 
   * Rebuild for repos.rcn-ee.com

--- a/binutils-pru/suite/buster/debian/changelog
+++ b/binutils-pru/suite/buster/debian/changelog
@@ -1,3 +1,11 @@
+binutils-pru (2.37.50.g2749ac13-0rcnee4~buster+20200321) buster; urgency=low
+
+  * Binutils 2.37.50, mainline commit 2749ac133972d027fe9482acc81f6e88c4f36812.
+  * Fix handling of .pri_irq_map section.
+  * Fix .resource_table section alignment for AM64x SoCs.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Sun, 12 Dec 2021 20:54:12 +0200
+
 binutils-pru (2.34-0rcnee4~buster+20200321) buster; urgency=low
 
   * Rebuild for repos.rcn-ee.com

--- a/binutils-pru/suite/stretch/debian/changelog
+++ b/binutils-pru/suite/stretch/debian/changelog
@@ -1,3 +1,11 @@
+binutils-pru (2.37.50.g2749ac13-0rcnee4~stretch+20200321) stretch; urgency=low
+
+  * Binutils 2.37.50, mainline commit 2749ac133972d027fe9482acc81f6e88c4f36812.
+  * Fix handling of .pri_irq_map section.
+  * Fix .resource_table section alignment for AM64x SoCs.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Sun, 12 Dec 2021 20:54:12 +0200
+
 binutils-pru (2.34-0rcnee4~stretch+20200321) stretch; urgency=low
 
   * Rebuild for repos.rcn-ee.com

--- a/binutils-pru/version.sh
+++ b/binutils-pru/version.sh
@@ -2,7 +2,7 @@
 
 package_name="binutils-pru"
 debian_pkg_name="${package_name}"
-package_version="2.34"
+package_version="2.37.50.g2749ac13"
 package_source=""
 src_dir=""
 

--- a/gcc-pru/generate_source.sh
+++ b/gcc-pru/generate_source.sh
@@ -5,7 +5,9 @@
 # rm *.tar.xz || true
 rm *.tar.bz2 || true
 
-wget http://ftpmirror.gnu.org/gcc/gcc-${package_version}/gcc-${package_version}.tar.xz
+# TODO - once GCC 12 is released, switch back to mainline tarballs.
+# wget http://ftpmirror.gnu.org/gcc/gcc-${package_version}/gcc-${package_version}.tar.xz
+wget http://dinux.eu/gnupru/gcc-${package_version}.tar.gz
 
 wget http://sourceware.org/pub/newlib/newlib-${newlib_version}.tar.gz
 
@@ -15,7 +17,7 @@ mkdir gcc-pru_${package_version}
 # Combine GCC and Newlib sources into a single source tarball.
 # This way we solve the multi-stage GCC build reliance on newlib.
 pushd gcc-pru_${package_version}
-tar --strip-components=1 -xaf ../gcc-${package_version}.tar.xz
+tar --strip-components=1 -xaf ../gcc-${package_version}.tar.??
 tar -xaf ../newlib-${newlib_version}.tar.gz
 mv newlib-*/newlib .
 mv newlib-*/libgloss .

--- a/gcc-pru/suite/bionic/debian/changelog
+++ b/gcc-pru/suite/bionic/debian/changelog
@@ -1,3 +1,9 @@
+gcc-pru (12.0.RC.gaeedb00a1a-0rcnee2~bionic+20200903) bionic; urgency=low
+
+  * Bump to GCC mainline commit aeedb00a1ae2ccd10b1a5f00ff466081aeadb54b.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Sun, 12 Dec 2021 21:59:11 +0200
+
 gcc-pru (10.1.0-0rcnee2~bionic+20200903) bionic; urgency=low
 
   * Rebuild for repos.rcn-ee.com

--- a/gcc-pru/suite/bionic/debian/control
+++ b/gcc-pru/suite/bionic/debian/control
@@ -10,8 +10,9 @@ Package: gcc-pru
 Architecture: any
 Section: devel
 Priority: extra
-Depends: ${shlibs:Depends}, ${misc:Depends}, binutils-pru (>= 2.30.51.20180310), gnuprumcu
+Depends: ${shlibs:Depends}, ${misc:Depends}, binutils-pru (>= 2.30.51.20180310)
 Provides: c-compiler-pru
+Recommends: gnuprumcu
 Suggests: task-c-devel, gcc-doc (>= 4:4.8), gcc (>= 4:4.8)
 Description: GNU C compiler (cross compiler for pru)
  This is the GNU C compiler, a fairly portable optimizing compiler which

--- a/gcc-pru/suite/bullseye/debian/changelog
+++ b/gcc-pru/suite/bullseye/debian/changelog
@@ -1,3 +1,9 @@
+gcc-pru (12.0.RC.gaeedb00a1a-0rcnee2~bullseye+20200903) bullseye; urgency=low
+
+  * Bump to GCC mainline commit aeedb00a1ae2ccd10b1a5f00ff466081aeadb54b.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Sun, 12 Dec 2021 21:59:11 +0200
+
 gcc-pru (10.1.0-0rcnee2~bullseye+20200903) bullseye; urgency=low
 
   * Rebuild for repos.rcn-ee.com

--- a/gcc-pru/suite/bullseye/debian/control
+++ b/gcc-pru/suite/bullseye/debian/control
@@ -10,8 +10,9 @@ Package: gcc-pru
 Architecture: any
 Section: devel
 Priority: extra
-Depends: ${shlibs:Depends}, ${misc:Depends}, binutils-pru (>= 2.30.51.20180310), gnuprumcu
+Depends: ${shlibs:Depends}, ${misc:Depends}, binutils-pru (>= 2.30.51.20180310)
 Provides: c-compiler-pru
+Recommends: gnuprumcu
 Suggests: task-c-devel, gcc-doc (>= 4:4.8), gcc (>= 4:4.8)
 Description: GNU C compiler (cross compiler for pru)
  This is the GNU C compiler, a fairly portable optimizing compiler which

--- a/gcc-pru/suite/buster/debian/changelog
+++ b/gcc-pru/suite/buster/debian/changelog
@@ -1,3 +1,9 @@
+gcc-pru (12.0.RC.gaeedb00a1a-0rcnee2~buster+20200903) buster; urgency=low
+
+  * Bump to GCC mainline commit aeedb00a1ae2ccd10b1a5f00ff466081aeadb54b.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Sun, 12 Dec 2021 21:59:11 +0200
+
 gcc-pru (10.1.0-0rcnee2~buster+20200903) buster; urgency=low
 
   * Rebuild for repos.rcn-ee.com

--- a/gcc-pru/suite/buster/debian/control
+++ b/gcc-pru/suite/buster/debian/control
@@ -10,8 +10,9 @@ Package: gcc-pru
 Architecture: any
 Section: devel
 Priority: extra
-Depends: ${shlibs:Depends}, ${misc:Depends}, binutils-pru (>= 2.30.51.20180310), gnuprumcu
+Depends: ${shlibs:Depends}, ${misc:Depends}, binutils-pru (>= 2.30.51.20180310)
 Provides: c-compiler-pru
+Recommends: gnuprumcu
 Suggests: task-c-devel, gcc-doc (>= 4:4.8), gcc (>= 4:4.8)
 Description: GNU C compiler (cross compiler for pru)
  This is the GNU C compiler, a fairly portable optimizing compiler which

--- a/gcc-pru/version.sh
+++ b/gcc-pru/version.sh
@@ -2,11 +2,11 @@
 
 package_name="gcc-pru"
 debian_pkg_name="${package_name}"
-package_version="10.1.0"
+package_version="12.0.RC.gaeedb00a1a"
 package_source=""
 src_dir=""
 
-newlib_version="3.3.0"
+newlib_version="4.1.0"
 
 git_repo=""
 git_sha=""

--- a/gnuprumcu/suite/bionic/debian/changelog
+++ b/gnuprumcu/suite/bionic/debian/changelog
@@ -1,3 +1,32 @@
+gnuprumcu (0.7.0) unstable; urgency=medium
+
+  * Add definitions for direct access to __R30 and __R31.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Fri, 10 Dec 2021 22:16:58 +0200
+
+gnuprumcu (0.6.0) unstable; urgency=medium
+
+  * Require Binutils at least version 2.37.
+  * Require pru-gcc to be installed.
+  * Remove linker scripts. Instead set memory sizes from specs.
+  * Activate --gc-sections linker option by default.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Fri, 24 Jul 2021 22:11:58 +0200
+
+gnuprumcu (0.5.0) unstable; urgency=medium
+
+  * Add TDA4VM device specs and linker scripts.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Fri, 15 Jan 2021 21:18:27 +0200
+
+gnuprumcu (0.4.0) unstable; urgency=medium
+
+  * Added am65x linker scripts.
+  * Fixed am572x device spec names.
+  * Fixed am437x IMEM size for ICSS1.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Sat, 28 Nov 2020 10:02:00 +0200
+
 gnuprumcu (0.3.0-git20200828.0-0rcnee0~bionic+20200903) bionic; urgency=low
 
   * Rebuild for repos.rcn-ee.com

--- a/gnuprumcu/suite/bionic/debian/control
+++ b/gnuprumcu/suite/bionic/debian/control
@@ -2,7 +2,7 @@ Source: gnuprumcu
 Section: embedded
 Priority: optional
 Maintainer: Dimitar Dimitrov <dimitar@dinux.eu>
-Build-Depends: debhelper (>= 11), autotools-dev
+Build-Depends: debhelper (>= 11), autotools-dev, binutils-pru (>= 2.37), gcc-pru (>=11.1)
 Standards-Version: 4.1.3
 Homepage: https://gitlab.com/dinuxbg/gnuprumcu
 #Vcs-Browser: https://salsa.debian.org/debian/gnuprumcu
@@ -10,7 +10,7 @@ Homepage: https://gitlab.com/dinuxbg/gnuprumcu
 
 Package: gnuprumcu
 Architecture: any
-Depends: ${misc:Depends}
+Depends: ${misc:Depends}, binutils-pru (>= 2.37), gcc-pru (>=11.1)
 Description: Linker scripts and device specs for PRU MCU variants
  This package contains the linker scripts, device specs and I/O headers
  for the different PRU variants in different TI SoCs. Install this package

--- a/gnuprumcu/suite/bionic/debian/rules
+++ b/gnuprumcu/suite/bionic/debian/rules
@@ -9,12 +9,12 @@ DEB_BUILD_OPTIONS=noautodbgsym
 
 %:
 	dh $@ \
-		--target=pru \
+		--host=pru \
 		--prefix=/usr/lib \
 		--with autoreconf \
 
 
 # dh_make generated override targets
 override_dh_auto_configure:
-	dh_auto_configure -- --target=pru --prefix=/usr/lib
+	dh_auto_configure -- --host=pru --prefix=/usr/lib
 

--- a/gnuprumcu/suite/bullseye/debian/changelog
+++ b/gnuprumcu/suite/bullseye/debian/changelog
@@ -1,3 +1,32 @@
+gnuprumcu (0.7.0) unstable; urgency=medium
+
+  * Add definitions for direct access to __R30 and __R31.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Fri, 10 Dec 2021 22:16:58 +0200
+
+gnuprumcu (0.6.0) unstable; urgency=medium
+
+  * Require Binutils at least version 2.37.
+  * Require pru-gcc to be installed.
+  * Remove linker scripts. Instead set memory sizes from specs.
+  * Activate --gc-sections linker option by default.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Fri, 24 Jul 2021 22:11:58 +0200
+
+gnuprumcu (0.5.0) unstable; urgency=medium
+
+  * Add TDA4VM device specs and linker scripts.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Fri, 15 Jan 2021 21:18:27 +0200
+
+gnuprumcu (0.4.0) unstable; urgency=medium
+
+  * Added am65x linker scripts.
+  * Fixed am572x device spec names.
+  * Fixed am437x IMEM size for ICSS1.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Sat, 28 Nov 2020 10:02:00 +0200
+
 gnuprumcu (0.3.0-git20200828.0-0rcnee0~bullseye+20200903) bullseye; urgency=low
 
   * Rebuild for repos.rcn-ee.com

--- a/gnuprumcu/suite/bullseye/debian/control
+++ b/gnuprumcu/suite/bullseye/debian/control
@@ -2,7 +2,7 @@ Source: gnuprumcu
 Section: embedded
 Priority: optional
 Maintainer: Dimitar Dimitrov <dimitar@dinux.eu>
-Build-Depends: debhelper (>= 11), autotools-dev
+Build-Depends: debhelper (>= 11), autotools-dev, binutils-pru (>= 2.37), gcc-pru (>=11.1)
 Standards-Version: 4.1.3
 Homepage: https://gitlab.com/dinuxbg/gnuprumcu
 #Vcs-Browser: https://salsa.debian.org/debian/gnuprumcu
@@ -10,7 +10,7 @@ Homepage: https://gitlab.com/dinuxbg/gnuprumcu
 
 Package: gnuprumcu
 Architecture: any
-Depends: ${misc:Depends}
+Depends: ${misc:Depends}, binutils-pru (>= 2.37), gcc-pru (>=11.1)
 Description: Linker scripts and device specs for PRU MCU variants
  This package contains the linker scripts, device specs and I/O headers
  for the different PRU variants in different TI SoCs. Install this package

--- a/gnuprumcu/suite/bullseye/debian/rules
+++ b/gnuprumcu/suite/bullseye/debian/rules
@@ -7,12 +7,12 @@
 
 %:
 	dh $@ \
-		--target=pru \
+		--host=pru \
 		--prefix=/usr/lib \
 		--with autoreconf \
 
 
 # dh_make generated override targets
 override_dh_auto_configure:
-	dh_auto_configure -- --target=pru --prefix=/usr/lib
+	dh_auto_configure -- --host=pru --prefix=/usr/lib
 

--- a/gnuprumcu/suite/buster/debian/changelog
+++ b/gnuprumcu/suite/buster/debian/changelog
@@ -1,3 +1,32 @@
+gnuprumcu (0.7.0) unstable; urgency=medium
+
+  * Add definitions for direct access to __R30 and __R31.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Fri, 10 Dec 2021 22:16:58 +0200
+
+gnuprumcu (0.6.0) unstable; urgency=medium
+
+  * Require Binutils at least version 2.37.
+  * Require pru-gcc to be installed.
+  * Remove linker scripts. Instead set memory sizes from specs.
+  * Activate --gc-sections linker option by default.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Fri, 24 Jul 2021 22:11:58 +0200
+
+gnuprumcu (0.5.0) unstable; urgency=medium
+
+  * Add TDA4VM device specs and linker scripts.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Fri, 15 Jan 2021 21:18:27 +0200
+
+gnuprumcu (0.4.0) unstable; urgency=medium
+
+  * Added am65x linker scripts.
+  * Fixed am572x device spec names.
+  * Fixed am437x IMEM size for ICSS1.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Sat, 28 Nov 2020 10:02:00 +0200
+
 gnuprumcu (0.3.0-git20200828.0-0rcnee0~buster+20200903) buster; urgency=low
 
   * Rebuild for repos.rcn-ee.com

--- a/gnuprumcu/suite/buster/debian/control
+++ b/gnuprumcu/suite/buster/debian/control
@@ -2,7 +2,7 @@ Source: gnuprumcu
 Section: embedded
 Priority: optional
 Maintainer: Dimitar Dimitrov <dimitar@dinux.eu>
-Build-Depends: debhelper (>= 11), autotools-dev
+Build-Depends: debhelper (>= 11), autotools-dev, binutils-pru (>= 2.37), gcc-pru (>=11.1)
 Standards-Version: 4.1.3
 Homepage: https://gitlab.com/dinuxbg/gnuprumcu
 #Vcs-Browser: https://salsa.debian.org/debian/gnuprumcu
@@ -10,7 +10,7 @@ Homepage: https://gitlab.com/dinuxbg/gnuprumcu
 
 Package: gnuprumcu
 Architecture: any
-Depends: ${misc:Depends}
+Depends: ${misc:Depends}, binutils-pru (>= 2.37), gcc-pru (>=11.1)
 Description: Linker scripts and device specs for PRU MCU variants
  This package contains the linker scripts, device specs and I/O headers
  for the different PRU variants in different TI SoCs. Install this package

--- a/gnuprumcu/suite/buster/debian/rules
+++ b/gnuprumcu/suite/buster/debian/rules
@@ -7,12 +7,12 @@
 
 %:
 	dh $@ \
-		--target=pru \
+		--host=pru \
 		--prefix=/usr/lib \
 		--with autoreconf \
 
 
 # dh_make generated override targets
 override_dh_auto_configure:
-	dh_auto_configure -- --target=pru --prefix=/usr/lib
+	dh_auto_configure -- --host=pru --prefix=/usr/lib
 

--- a/gnuprumcu/version.sh
+++ b/gnuprumcu/version.sh
@@ -2,12 +2,12 @@
 
 package_name="gnuprumcu"
 debian_pkg_name="${package_name}"
-package_version="0.3.0-git20200828.0"
+package_version="0.7.0-git20211212.0"
 package_source="${package_name}_${package_version}.orig.tar.xz"
 src_dir="${package_name}_${package_version}"
 
 git_repo="https://github.com/dinuxbg/gnuprumcu"
-git_sha="b62dfbc2cf1e8ad19e845141e7e3a6c077a6c4d5"
+git_sha="aa0fced67d9d03c21e40caa5f8e5820c7264f2b5"
 reprepro_dir="b/${package_name}"
 dl_path=""
 


### PR DESCRIPTION
This update is needed to allow loading of GCC-built PRU firmware by
mainline kernels 5.10 and later. I've tested on armhf bullseye chroot
with qemu, on amd64 host.

The necessary fixes for kernel 5.10 remoteproc are already merged
upstream:
  https://sourceware.org/pipermail/binutils/2021-September/118057.html
  https://sourceware.org/pipermail/binutils/2021-November/118668.html
  https://gcc.gnu.org/pipermail/gcc-patches/2021-December/586176.html

While waiting for the official Binutils 2.38 and GCC 12 releases, let's
use locally-generated snapshot tarballs. They have been created from
non-modified GIT HEADs of upstream development trees:
   binutils: commit 2749ac133972d027fe9482acc81f6e88c4f36812
   gcc: commit aeedb00a1ae2ccd10b1a5f00ff466081aeadb54b
I'll host those tarballs for at least one more year. By then we should
update to the official upstream releases.

One notable change is that now gnuprumcu package must be built last,
after binutils-pru and gcc-pru.

Signed-off-by: Dimitar Dimitrov <dimitar@dinux.eu>