### PR TITLE
bb-simppru: Add gnuprumcu dependency

### DIFF
--- a/bb-simppru/suite/bullseye/debian/control
+++ b/bb-simppru/suite/bullseye/debian/control
@@ -8,12 +8,13 @@ Build-Depends:  debhelper (>= 9),
 		cmake,
 		flex,
 		gcc-pru,
+		gnuprumcu,
 		git,
 Standards-Version: 3.9.8
 Homepage: https://github.com/VedantParanjape/simpPRU
 
 Package: bb-simppru
 Architecture: armhf
-Depends: ${shlibs:Depends}, ${misc:Depends}, gcc-pru
+Depends: ${shlibs:Depends}, ${misc:Depends}, gcc-pru, gnuprumcu
 Description: beagleboard.org simppru
  beagleboard.org simppru for beagleboard devices

--- a/bb-simppru/suite/buster/debian/control
+++ b/bb-simppru/suite/buster/debian/control
@@ -8,12 +8,13 @@ Build-Depends:  debhelper (>= 9),
 		cmake,
 		flex,
 		gcc-pru,
+		gnuprumcu,
 		git,
 Standards-Version: 3.9.8
 Homepage: https://github.com/VedantParanjape/simpPRU
 
 Package: bb-simppru
 Architecture: armhf
-Depends: ${shlibs:Depends}, ${misc:Depends}, gcc-pru
+Depends: ${shlibs:Depends}, ${misc:Depends}, gcc-pru, gnuprumcu
 Description: beagleboard.org simppru
  beagleboard.org simppru for beagleboard devices


### PR DESCRIPTION
Now that gcc-pru does not depend on gnuprumcu, we need to explicitly
mention it.

I managed to build bb-simppru_1.4.20211012.1-0/bb-simppru_1.4
.20211012.1-0~bullseye+20211228_armhf.deb using GCC 12 and Gnuprumcu v0.7.0.

Signed-off-by: Dimitar Dimitrov <dimitar@dinux.eu>