### PR TITLE
binutils-pru: Bump to official 2.38 release

### DIFF
--- a/binutils-pru/generate_source.sh
+++ b/binutils-pru/generate_source.sh
@@ -7,9 +7,7 @@ do
   OLD=`pwd`
   cd $d
   rm *.tar.bz2 || true
-  # TODO - once Binutils 2.38 is released, switch back to official tarballs.
-  # wget http://ftpmirror.gnu.org/binutils/binutils-${package_version}.tar.bz2
-  wget http://dinux.eu/gnupru/binutils-2.37.50.g2749ac13.tar.bz2
+  wget http://ftpmirror.gnu.org/binutils/binutils-${package_version}.tar.bz2
   cd $OLD
 done
 

--- a/binutils-pru/suite/bionic/debian/changelog
+++ b/binutils-pru/suite/bionic/debian/changelog
@@ -1,3 +1,9 @@
+binutils-pru (2.38-0rcnee4~bionic+20200321) bionic; urgency=low
+
+  * Binutils 2.38 official release.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Sun, 13 Feb 2022 15:24:12 +0200
+
 binutils-pru (2.37.50.g2749ac13-0rcnee4~bionic+20200321) bionic; urgency=low
 
   * Binutils 2.37.50, mainline commit 2749ac133972d027fe9482acc81f6e88c4f36812.

--- a/binutils-pru/suite/bullseye/debian/changelog
+++ b/binutils-pru/suite/bullseye/debian/changelog
@@ -1,3 +1,9 @@
+binutils-pru (2.38-0rcnee4~bionic+20200321) bullseye; urgency=low
+
+  * Binutils 2.38 official release.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Sun, 13 Feb 2022 15:24:12 +0200
+
 binutils-pru (2.37.50.g2749ac13-0rcnee4~bullseye+20200321) bullseye; urgency=low
 
   * Binutils 2.37.50, mainline commit 2749ac133972d027fe9482acc81f6e88c4f36812.

--- a/binutils-pru/suite/buster/debian/changelog
+++ b/binutils-pru/suite/buster/debian/changelog
@@ -1,3 +1,9 @@
+binutils-pru (2.38-0rcnee4~bionic+20200321) buster; urgency=low
+
+  * Binutils 2.38 official release.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Sun, 13 Feb 2022 15:24:12 +0200
+
 binutils-pru (2.37.50.g2749ac13-0rcnee4~buster+20200321) buster; urgency=low
 
   * Binutils 2.37.50, mainline commit 2749ac133972d027fe9482acc81f6e88c4f36812.

--- a/binutils-pru/suite/stretch/debian/changelog
+++ b/binutils-pru/suite/stretch/debian/changelog
@@ -1,3 +1,9 @@
+binutils-pru (2.38-0rcnee4~bionic+20200321) stretch; urgency=low
+
+  * Binutils 2.38 official release.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Sun, 13 Feb 2022 15:24:12 +0200
+
 binutils-pru (2.37.50.g2749ac13-0rcnee4~stretch+20200321) stretch; urgency=low
 
   * Binutils 2.37.50, mainline commit 2749ac133972d027fe9482acc81f6e88c4f36812.

--- a/binutils-pru/version.sh
+++ b/binutils-pru/version.sh
@@ -2,7 +2,7 @@
 
 package_name="binutils-pru"
 debian_pkg_name="${package_name}"
-package_version="2.37.50.g2749ac13"
+package_version="2.38"
 package_source=""
 src_dir=""
 


### PR DESCRIPTION
Not much changes affecting the PRU backend.

Signed-off-by: Dimitar Dimitrov <dimitar@dinux.eu>