### PR TITLE
binutils-pru: Disable libctf and sim

### DIFF
--- a/binutils-pru/suite/bionic/debian/rules
+++ b/binutils-pru/suite/bionic/debian/rules
@@ -21,6 +21,8 @@ CONFARGS = --prefix=/usr \
            --with-gnu-ld \
            --with-gnu-as \
            --disable-gdb \
+           --disable-sim \
+           --disable-libctf \
            --enable-install-libbfd \
 	   --with-bugurl="https://github.com/dinuxbg/gnupru/issues" \
            $(shell dpkg-buildflags --export=configure) 
@@ -116,7 +118,8 @@ install: build
 	rm -rf lib/libiberty.* lib/libbfd.* lib/libopcodes* \
 	include/bfd.h include/ansidecl.h include/bfdlink.h \
 	share/locale include/symcat.h include/dis-asm.h \
-	info share/info share/gdb include/gdb/jit-reader.h
+	info share/info share/gdb include/gdb/jit-reader.h \
+	lib/bfd-plugins/
 
 	mv debian/binutils-pru/usr/$(DEB_HOST_GNU_TYPE)/pru \
 	   debian/binutils-pru/usr/lib/pru/$(DEB_HOST_GNU_TYPE)

--- a/binutils-pru/suite/bullseye/debian/rules
+++ b/binutils-pru/suite/bullseye/debian/rules
@@ -19,6 +19,8 @@ CONFARGS = --prefix=/usr \
            --with-gnu-ld \
            --with-gnu-as \
            --disable-gdb \
+           --disable-sim \
+           --disable-libctf \
            --enable-install-libbfd \
 	   --with-bugurl="https://github.com/dinuxbg/gnupru/issues" \
            $(shell dpkg-buildflags --export=configure) 
@@ -114,7 +116,8 @@ install: build
 	rm -rf lib/libiberty.* lib/libbfd.* lib/libopcodes* \
 	include/bfd.h include/ansidecl.h include/bfdlink.h \
 	share/locale include/symcat.h include/dis-asm.h \
-	info share/info share/gdb include/gdb/jit-reader.h
+	info share/info share/gdb include/gdb/jit-reader.h \
+	lib/bfd-plugins/
 
 	mv debian/binutils-pru/usr/$(DEB_HOST_GNU_TYPE)/pru \
 	   debian/binutils-pru/usr/lib/pru/$(DEB_HOST_GNU_TYPE)

--- a/binutils-pru/suite/buster/debian/rules
+++ b/binutils-pru/suite/buster/debian/rules
@@ -19,6 +19,8 @@ CONFARGS = --prefix=/usr \
            --with-gnu-ld \
            --with-gnu-as \
            --disable-gdb \
+           --disable-sim \
+           --disable-libctf \
            --enable-install-libbfd \
 	   --with-bugurl="https://github.com/dinuxbg/gnupru/issues" \
            $(shell dpkg-buildflags --export=configure) 
@@ -114,7 +116,8 @@ install: build
 	rm -rf lib/libiberty.* lib/libbfd.* lib/libopcodes* \
 	include/bfd.h include/ansidecl.h include/bfdlink.h \
 	share/locale include/symcat.h include/dis-asm.h \
-	info share/info share/gdb include/gdb/jit-reader.h
+	info share/info share/gdb include/gdb/jit-reader.h \
+	lib/bfd-plugins/
 
 	mv debian/binutils-pru/usr/$(DEB_HOST_GNU_TYPE)/pru \
 	   debian/binutils-pru/usr/lib/pru/$(DEB_HOST_GNU_TYPE)

--- a/binutils-pru/suite/stretch/debian/rules
+++ b/binutils-pru/suite/stretch/debian/rules
@@ -19,6 +19,8 @@ CONFARGS = --prefix=/usr \
            --with-gnu-ld \
            --with-gnu-as \
            --disable-gdb \
+           --disable-sim \
+           --disable-libctf \
            --enable-install-libbfd \
 	   --with-bugurl="https://github.com/dinuxbg/gnupru/issues" \
            $(shell dpkg-buildflags --export=configure) 
@@ -114,7 +116,8 @@ install: build
 	rm -rf lib/libiberty.* lib/libbfd.* lib/libopcodes* \
 	include/bfd.h include/ansidecl.h include/bfdlink.h \
 	share/locale include/symcat.h include/dis-asm.h \
-	info share/info share/gdb include/gdb/jit-reader.h
+	info share/info share/gdb include/gdb/jit-reader.h \
+	lib/bfd-plugins/
 
 	mv debian/binutils-pru/usr/$(DEB_HOST_GNU_TYPE)/pru \
 	   debian/binutils-pru/usr/lib/pru/$(DEB_HOST_GNU_TYPE)


### PR DESCRIPTION
We don't need libctf for PRU. Simulator is only really useful for
regression-testing the toolchain, so no point in keeping it in the
Debian package.

This should fix simultaneous installation of Binutils packages for
different targets (PRU, AVR, MSP430).

Also remove bfd plugin directory. It's not needed. And it conflicts with
binutils packages for other targets.

Signed-off-by: Dimitar Dimitrov <dimitar@dinux.eu>