### PR TITLE
gcc-pru: Bump to official GCC 12.1 release

### DIFF
--- a/gcc-pru-debian-11-ubuntu-2004/generate_source.sh
+++ b/gcc-pru-debian-11-ubuntu-2004/generate_source.sh
@@ -5,9 +5,7 @@
 # rm *.tar.xz || true
 rm *.tar.bz2 || true
 
-# TODO - once GCC 12 is released, switch back to mainline tarballs.
-# wget http://ftpmirror.gnu.org/gcc/gcc-${package_version}/gcc-${package_version}.tar.xz
-wget http://dinux.eu/gnupru/gcc-${package_version}.tar.gz
+wget http://ftpmirror.gnu.org/gcc/gcc-${package_version}/gcc-${package_version}.tar.xz
 
 wget http://sourceware.org/pub/newlib/newlib-${newlib_version}.tar.gz
 

--- a/gcc-pru-debian-11-ubuntu-2004/version.sh
+++ b/gcc-pru-debian-11-ubuntu-2004/version.sh
@@ -2,7 +2,7 @@
 
 package_name="gcc-pru"
 debian_pkg_name="${package_name}"
-package_version="12.0.RC.gaeedb00a1a"
+package_version="12.1.0"
 package_source=""
 src_dir=""
 

--- a/gcc-pru/generate_source.sh
+++ b/gcc-pru/generate_source.sh
@@ -5,9 +5,7 @@
 # rm *.tar.xz || true
 rm *.tar.bz2 || true
 
-# TODO - once GCC 12 is released, switch back to mainline tarballs.
-# wget http://ftpmirror.gnu.org/gcc/gcc-${package_version}/gcc-${package_version}.tar.xz
-wget http://dinux.eu/gnupru/gcc-${package_version}.tar.gz
+wget http://ftpmirror.gnu.org/gcc/gcc-${package_version}/gcc-${package_version}.tar.xz
 
 wget http://sourceware.org/pub/newlib/newlib-${newlib_version}.tar.gz
 

--- a/gcc-pru/version.sh
+++ b/gcc-pru/version.sh
@@ -2,7 +2,7 @@
 
 package_name="gcc-pru"
 debian_pkg_name="${package_name}"
-package_version="12.0.RC.gaeedb00a1a"
+package_version="12.1.0"
 package_source=""
 src_dir=""
 


### PR DESCRIPTION
There are no functional changes since the last RC release which would
concern the PRU target.

Tested only that source file is generated, without the Debian
packaging steps:
  cd gcc-pru
  ./generate_source.sh

Build itself should be fine, judging from the daily builtbot test
results [1].

[1] https://gcc.gnu.org/pipermail/gcc-testresults/2022-April/760162.html

Signed-off-by: Dimitar Dimitrov <dimitar@dinux.eu>