### PR TITLE
gnuprumcu: Bump to v0.9.0

### DIFF
--- a/gnuprumcu-debian-11-ubuntu-2004/suite/bullseye/debian/changelog
+++ b/gnuprumcu-debian-11-ubuntu-2004/suite/bullseye/debian/changelog
@@ -1,3 +1,11 @@
+gnuprumcu (0.9.0) bullseye; urgency=low
+
+  * Add TDA4VM (J721E) specs and headers.
+  * Add alias macros used by TI examples.
+  * Add AM62x specs.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Sat, 10 Sep 2022 23:09:42 +0200
+
 gnuprumcu (0.7.0-git20211212.0-0rcnee0~bullseye+20211224) bullseye; urgency=low
 
   * Rebuild for repos.rcn-ee.com

--- a/gnuprumcu-debian-11-ubuntu-2004/suite/focal/debian/changelog
+++ b/gnuprumcu-debian-11-ubuntu-2004/suite/focal/debian/changelog
@@ -1,3 +1,11 @@
+gnuprumcu (0.9.0) focal; urgency=medium
+
+  * Add TDA4VM (J721E) specs and headers.
+  * Add alias macros used by TI examples.
+  * Add AM62x specs.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Sat, 10 Sep 2022 23:09:42 +0200
+
 gnuprumcu (0.7.0-git20211212.0-0rcnee0~focal+20211224) focal; urgency=low
 
   * Rebuild for repos.rcn-ee.com

--- a/gnuprumcu-debian-11-ubuntu-2004/version.sh
+++ b/gnuprumcu-debian-11-ubuntu-2004/version.sh
@@ -2,12 +2,12 @@
 
 package_name="gnuprumcu"
 debian_pkg_name="${package_name}"
-package_version="0.7.0-git20211212.0"
+package_version="0.9.0-git20220910.0"
 package_source="${package_name}_${package_version}.orig.tar.xz"
 src_dir="${package_name}_${package_version}"
 
 git_repo="https://github.com/dinuxbg/gnuprumcu"
-git_sha="aa0fced67d9d03c21e40caa5f8e5820c7264f2b5"
+git_sha="98b2f1e57eb5d623d717e4431c4e3d6f59fd2d3b"
 reprepro_dir="b/${package_name}"
 dl_path=""
 

--- a/gnuprumcu/suite/bionic/debian/changelog
+++ b/gnuprumcu/suite/bionic/debian/changelog
@@ -1,3 +1,11 @@
+gnuprumcu (0.9.0) unstable; urgency=medium
+
+  * Add TDA4VM (J721E) specs and headers.
+  * Add alias macros used by TI examples.
+  * Add AM62x specs.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Sat, 10 Sep 2022 23:09:42 +0200
+
 gnuprumcu (0.7.0) unstable; urgency=medium
 
   * Add definitions for direct access to __R30 and __R31.

--- a/gnuprumcu/suite/bullseye/debian/changelog
+++ b/gnuprumcu/suite/bullseye/debian/changelog
@@ -1,3 +1,11 @@
+gnuprumcu (0.9.0) unstable; urgency=medium
+
+  * Add TDA4VM (J721E) specs and headers.
+  * Add alias macros used by TI examples.
+  * Add AM62x specs.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Sat, 10 Sep 2022 23:09:42 +0200
+
 gnuprumcu (0.7.0) unstable; urgency=medium
 
   * Add definitions for direct access to __R30 and __R31.

--- a/gnuprumcu/suite/buster/debian/changelog
+++ b/gnuprumcu/suite/buster/debian/changelog
@@ -1,3 +1,11 @@
+gnuprumcu (0.9.0) unstable; urgency=medium
+
+  * Add TDA4VM (J721E) specs and headers.
+  * Add alias macros used by TI examples.
+  * Add AM62x specs.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Sat, 10 Sep 2022 23:09:42 +0200
+
 gnuprumcu (0.7.0) unstable; urgency=medium
 
   * Add definitions for direct access to __R30 and __R31.

--- a/gnuprumcu/version.sh
+++ b/gnuprumcu/version.sh
@@ -2,12 +2,12 @@
 
 package_name="gnuprumcu"
 debian_pkg_name="${package_name}"
-package_version="0.7.0-git20211212.0"
+package_version="0.9.0-git20220910.0"
 package_source="${package_name}_${package_version}.orig.tar.xz"
 src_dir="${package_name}_${package_version}"
 
 git_repo="https://github.com/dinuxbg/gnuprumcu"
-git_sha="aa0fced67d9d03c21e40caa5f8e5820c7264f2b5"
+git_sha="98b2f1e57eb5d623d717e4431c4e3d6f59fd2d3b"
 reprepro_dir="b/${package_name}"
 dl_path=""
 


### PR DESCRIPTION
This version adds support for Beaglebone-AI64 with PRU GCC.

Signed-off-by: Dimitar Dimitrov <dimitar@dinux.eu>