### PR TITLE
Update GNU PRU toolchain

### DIFF
--- a/binutils-pru/generate_source.sh
+++ b/binutils-pru/generate_source.sh
@@ -10,4 +10,3 @@ do
   wget http://ftpmirror.gnu.org/binutils/binutils-${package_version}.tar.bz2
   cd $OLD
 done
-

--- a/binutils-pru/suite/bionic/debian/changelog
+++ b/binutils-pru/suite/bionic/debian/changelog
@@ -1,3 +1,9 @@
+binutils-pru (2.41-0rcnee5~bionic+20230731) bionic; urgency=low
+
+  * Binutils 2.41.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Mon, 31 Jul 2023 21:14:12 +0200
+
 binutils-pru (2.38-0rcnee4~bionic+20200321) bionic; urgency=low
 
   * Binutils 2.38 official release.

--- a/binutils-pru/suite/bullseye/debian/changelog
+++ b/binutils-pru/suite/bullseye/debian/changelog
@@ -1,3 +1,9 @@
+binutils-pru (2.41-0rcnee5~bullseye+20230731) bullseye; urgency=low
+
+  * Binutils 2.41.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Mon, 31 Jul 2023 21:14:12 +0200
+
 binutils-pru (2.38-0rcnee4~bionic+20200321) bullseye; urgency=low
 
   * Binutils 2.38 official release.

--- a/binutils-pru/suite/buster/debian/changelog
+++ b/binutils-pru/suite/buster/debian/changelog
@@ -1,3 +1,9 @@
+binutils-pru (2.41-0rcnee5~bullseye+20230731) buster; urgency=low
+
+  * Binutils 2.41.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Mon, 31 Jul 2023 21:14:12 +0200
+
 binutils-pru (2.38-0rcnee4~bionic+20200321) buster; urgency=low
 
   * Binutils 2.38 official release.

--- a/binutils-pru/version.sh
+++ b/binutils-pru/version.sh
@@ -2,7 +2,7 @@
 
 package_name="binutils-pru"
 debian_pkg_name="${package_name}"
-package_version="2.38"
+package_version="2.41"
 package_source=""
 src_dir=""
 

--- a/gcc-pru/suite/bionic/debian/changelog
+++ b/gcc-pru/suite/bionic/debian/changelog
@@ -1,3 +1,9 @@
+gcc-pru (13.2.0-0rcnee0~bullseye+20230731) bionic; urgency=low
+
+  * Bump to GCC mainline 13.2.0
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Mon, 31 Jul 2023 22:59:11 +0200
+
 gcc-pru (12.0.RC.gaeedb00a1a-0rcnee2~bionic+20200903) bionic; urgency=low
 
   * Bump to GCC mainline commit aeedb00a1ae2ccd10b1a5f00ff466081aeadb54b.

--- a/gcc-pru/suite/bullseye/debian/changelog
+++ b/gcc-pru/suite/bullseye/debian/changelog
@@ -1,3 +1,9 @@
+gcc-pru (13.2.0-0rcnee0~bullseye+20230731) bullseye; urgency=low
+
+  * Bump to GCC mainline 13.2.0
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Mon, 31 Jul 2023 22:59:11 +0200
+
 gcc-pru (12.0.RC.gaeedb00a1a-0rcnee2~bullseye+20200903) bullseye; urgency=low
 
   * Bump to GCC mainline commit aeedb00a1ae2ccd10b1a5f00ff466081aeadb54b.

--- a/gcc-pru/suite/buster/debian/changelog
+++ b/gcc-pru/suite/buster/debian/changelog
@@ -1,3 +1,9 @@
+gcc-pru (13.2.0-0rcnee0~bullseye+20230731) buster; urgency=low
+
+  * Bump to GCC mainline 13.2.0
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Mon, 31 Jul 2023 22:59:11 +0200
+
 gcc-pru (12.0.RC.gaeedb00a1a-0rcnee2~buster+20200903) buster; urgency=low
 
   * Bump to GCC mainline commit aeedb00a1ae2ccd10b1a5f00ff466081aeadb54b.

--- a/gcc-pru/version.sh
+++ b/gcc-pru/version.sh
@@ -2,11 +2,11 @@
 
 package_name="gcc-pru"
 debian_pkg_name="${package_name}"
-package_version="12.1.0"
+package_version="13.2.0"
 package_source=""
 src_dir=""
 
-newlib_version="4.1.0"
+newlib_version="4.2.0.20211231"
 
 git_repo=""
 git_sha=""

--- a/gnuprumcu/suite/bionic/debian/control
+++ b/gnuprumcu/suite/bionic/debian/control
@@ -10,7 +10,7 @@ Homepage: https://gitlab.com/dinuxbg/gnuprumcu
 
 Package: gnuprumcu
 Architecture: any
-Depends: ${misc:Depends}, binutils-pru (>= 2.37), gcc-pru (>=11.1)
+Depends: ${misc:Depends}, binutils-pru (>= 2.41), gcc-pru (>=13.1)
 Description: Linker scripts and device specs for PRU MCU variants
  This package contains the linker scripts, device specs and I/O headers
  for the different PRU variants in different TI SoCs. Install this package

--- a/gnuprumcu/suite/bullseye/debian/changelog
+++ b/gnuprumcu/suite/bullseye/debian/changelog
@@ -1,3 +1,14 @@
+gnuprumcu (0.9.4) unstable; urgency=medium
+
+  * Add I/O header for am62x.
+  * Fix bit field length in AM572x's SPP register.
+  * Add linker commands to align sections.
+  * Add TDA4VM (J721E) specs and headers.
+  * Add alias macros used by TI examples.
+  * Add AM62x specs.
+
+ -- Dimitar Dimitrov <dimitar@dinux.eu>  Fri, 26 May 2023 22:16:58 +0200
+
 gnuprumcu (0.7.0) unstable; urgency=medium
 
   * Add definitions for direct access to __R30 and __R31.

--- a/gnuprumcu/suite/bullseye/debian/control
+++ b/gnuprumcu/suite/bullseye/debian/control
@@ -10,7 +10,7 @@ Homepage: https://gitlab.com/dinuxbg/gnuprumcu
 
 Package: gnuprumcu
 Architecture: any
-Depends: ${misc:Depends}, binutils-pru (>= 2.37), gcc-pru (>=11.1)
+Depends: ${misc:Depends}, binutils-pru (>= 2.41), gcc-pru (>=13.1)
 Description: Linker scripts and device specs for PRU MCU variants
  This package contains the linker scripts, device specs and I/O headers
  for the different PRU variants in different TI SoCs. Install this package

--- a/gnuprumcu/suite/buster/debian/control
+++ b/gnuprumcu/suite/buster/debian/control
@@ -10,7 +10,7 @@ Homepage: https://gitlab.com/dinuxbg/gnuprumcu
 
 Package: gnuprumcu
 Architecture: any
-Depends: ${misc:Depends}, binutils-pru (>= 2.37), gcc-pru (>=11.1)
+Depends: ${misc:Depends}, binutils-pru (>= 2.41), gcc-pru (>=13.1)
 Description: Linker scripts and device specs for PRU MCU variants
  This package contains the linker scripts, device specs and I/O headers
  for the different PRU variants in different TI SoCs. Install this package

--- a/gnuprumcu/version.sh
+++ b/gnuprumcu/version.sh
@@ -2,12 +2,12 @@
 
 package_name="gnuprumcu"
 debian_pkg_name="${package_name}"
-package_version="0.7.0-git20211212.0"
+package_version="0.9.4-git20230525.0"
 package_source="${package_name}_${package_version}.orig.tar.xz"
 src_dir="${package_name}_${package_version}"
 
 git_repo="https://github.com/dinuxbg/gnuprumcu"
-git_sha="aa0fced67d9d03c21e40caa5f8e5820c7264f2b5"
+git_sha="add29b89053bd5bd7157c6eb48c2f6963cf232da"
 reprepro_dir="b/${package_name}"
 dl_path=""
 


### PR DESCRIPTION
The updates are necessary to support PRUs on BeaglePlay and BBAI64.

 * gnuprumcu v0.9.4, with support for AM62x and TDA4VM.
 * GCC 13.2.0
 * Binutils 2.41